### PR TITLE
Fix XML IO bugs related to weird paths on e.g. Windows machine.

### DIFF
--- a/src/main/java/mpicbg/spim/data/XmlHelpers.java
+++ b/src/main/java/mpicbg/spim/data/XmlHelpers.java
@@ -294,7 +294,8 @@ public class XmlHelpers
 		if ( elem == null )
 			return null;
 		final String path = elem.getText();
-		final boolean isRelative = elem.getAttributeValue( "type" ).equals( "relative" );
+		final String pathType = elem.getAttributeValue( "type" );
+		final boolean isRelative = null != pathType && pathType.equals( "relative" );
 		if ( isRelative )
 		{
 			if ( basePath == null )

--- a/src/main/java/mpicbg/spim/data/XmlHelpers.java
+++ b/src/main/java/mpicbg/spim/data/XmlHelpers.java
@@ -312,13 +312,25 @@ public class XmlHelpers
 	public static Element pathElement( final String name, final File path, final File basePath )
 	{
 		final Element e = new Element( name );
-
 		if ( basePath == null )
+		{
+			e.setAttribute( "type", "absolute" );
 			e.setText( path.getAbsolutePath() );
+		}
 		else
 		{
-			e.setAttribute( "type", "relative" );
-			e.setText( getRelativePath( path, basePath ).getPath() );
+			// Try to build a relative path. If can't, make it absolute.
+			final File relativePath = getRelativePath( path, basePath );
+			if ( null == relativePath )
+			{
+				e.setAttribute( "type", "absolute" );
+				e.setText( path.getAbsolutePath() );
+			}
+			else
+			{
+				e.setAttribute( "type", "relative" );
+				e.setText( relativePath.getPath() );
+			}
 		}
 
 		return e;


### PR DESCRIPTION
For instance, fix NPE when saving to a windows network folder.
If the path to a XML file starts with `\\` like in:
`\\FORSITIA-PFID\TestMount\samples\datasethdf5.xml`
we get a NPE because we cannot build a relative path from a local drive to these locations.
Fix this by making path absolute when building a relative path fails.

Also, do not crash when loading a XML path without `type` attribute.
