### PR TITLE
Fix img loaders for spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>spim_data</artifactId>
-	<version>2.2.7-SNAPSHOT</version>
+	<version>2.2.8-SNAPSHOT</version>
 
 	<name>SPIM Data</name>
 	<description>representation of multi-angle, multi-channel (etc.) SPIM images and their registration</description>
@@ -145,6 +145,11 @@
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>
 			<artifactId>trove4j</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.32</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/mpicbg/spim/data/generic/sequence/ImgLoaders.java
+++ b/src/main/java/mpicbg/spim/data/generic/sequence/ImgLoaders.java
@@ -41,25 +41,22 @@ public class ImgLoaders
 
 	private static final HashMap< String, String > format_to_XmlIoClassName = new HashMap< String, String >();
 
-	// TODO FIX. this is not thread-safe!
 	private static boolean buildWasCalled = false;
 
-	private static void build()
+	private static synchronized void build()
 	{
-		buildWasCalled = true;
-		try
-		{
-			final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-			final Index< ImgLoaderIo > annotationIndex = Index.load( ImgLoaderIo.class, classLoader );
-			for ( final IndexItem< ImgLoaderIo > item : annotationIndex )
-			{
-				format_to_XmlIoClassName.put( item.annotation().format(), item.className() );
-				imgLoaderClass_to_XmlIoClassName.put( item.annotation().type(), item.className() );
+		if (! buildWasCalled) {
+			try {
+				final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+				final Index<ImgLoaderIo> annotationIndex = Index.load(ImgLoaderIo.class, classLoader);
+				for (final IndexItem<ImgLoaderIo> item : annotationIndex) {
+					format_to_XmlIoClassName.put(item.annotation().format(), item.className());
+					imgLoaderClass_to_XmlIoClassName.put(item.annotation().type(), item.className());
+				}
+			} catch (final Exception e) {
+				throw new RuntimeException("problem accessing annotation index", e);
 			}
-		}
-		catch( final Exception e )
-		{
-			throw new RuntimeException( "problem accessing annotation index", e );
+			buildWasCalled = true;
 		}
 	}
 


### PR DESCRIPTION
Hi @tpietzsch and @StephanPreibisch,

These commits fix the "could not find XmlIoBasicImgLoader implementation for format bdv.n5" issue @boazmohar identified in https://github.com/PreibischLab/BigStitcher-Spark/issues/2 .  The [first commit](https://github.com/bigdataviewer/spimdata/commit/bb43b3fe99f0285d4db1a581437258cd9eff5506) fixes the core problem.  The [second commit](https://github.com/bigdataviewer/spimdata/commit/d49721496a7b4e05f6f23e14ed7e9848c26bbaed) contains slf4j logging calls I added to help confirm what was happening.  The logging works well in the spark environment I used for testing, but I wasn't sure if it would cause trouble for other contexts in which spimdata is used.  Hopefully, separating the commits makes it easier for you to toss the logging stuff if necessary.

Best,
Eric