### PR TITLE
Make the getParent(URI) helper more robust

### DIFF
--- a/src/main/java/mpicbg/spim/data/generic/XmlIoAbstractSpimData.java
+++ b/src/main/java/mpicbg/spim/data/generic/XmlIoAbstractSpimData.java
@@ -199,12 +199,44 @@ public class XmlIoAbstractSpimData< S extends AbstractSequenceDescription< ?, ?,
 		return XmlHelpers.loadPathURI( root, BASEPATH_TAG, ".", parent );
 	}
 
+	/**
+	 * Gets a URI's parent, e.g. the containing directory of a file.
+	 * <p>
+	 * This function behaves differently than the invocation
+	 * {@code uri.resolve("..")} when the URI ends in a trailing slash:
+	 * </p>
+	 * <pre>{@code
+	 * jshell> new URI("file:/foo/bar/").resolve("..")
+	 * $1 ==> file:/foo/
+	 *
+	 * jshell> new URI("file:/foo/bar").resolve("..")
+	 * $2 ==> file:/
+	 * }</pre>
+	 * <p>
+	 * Whereas this function returns "file:/foo/" in both cases.
+	 */
 	private static URI getParent( final URI uri ) throws SpimDataIOException
 	{
 		try
 		{
-			final String parent = Paths.get( uri.getPath() ).getParent().toString() + "/";
-			return new URI( uri.getScheme(), uri.getAuthority(), parent, uri.getQuery(), uri.getFragment() );
+			final String uriPath = uri.getPath();
+			final int parentSlash = uriPath.lastIndexOf( "/", uriPath.length() - 2 );
+			if ( parentSlash < 0 )
+			{
+				throw new SpimDataIOException( "URI is already at the root" );
+			}
+			// NB: The "+ 1" below is *very important*, so that the resultant URI
+			// ends in a trailing slash. The behaviour of URI differs depending on
+			// whether this trailing slash is present; specifically:
+			//
+			// * new URI("file:/foo/bar/").resolve(".") -> "file:/foo/bar/"
+			// * new URI("file:/foo/bar").resolve(".") -> "file:/foo/"
+			//
+			// That is: /foo/bar/ is considered to be in the directory /foo/bar,
+			// whereas /foo/bar is considered to be in the directory /foo.
+			final String parentPath = uriPath.substring( 0, parentSlash + 1 );
+			return new URI( uri.getScheme(), uri.getUserInfo(), uri.getHost(),
+				uri.getPort(), parentPath, uri.getQuery(), uri.getFragment() );
 		}
 		catch ( URISyntaxException e )
 		{


### PR DESCRIPTION
This fixes the behavior on Windows, avoiding `InvalidPathException`s.

Consequently, it fixes downstream test failures in components including labkit-ui and others.

See also [relevant discussion on Zulip](https://imagesc.zulipchat.com/#narrow/stream/327237-SciJava/topic/pom-scijava.2039.20melting.20pot.20issues/near/475141286).
